### PR TITLE
Drop dependency on `ostruct`

### DIFF
--- a/hutch.gemspec
+++ b/hutch.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'carrot-top', '~> 0.0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.15'
   gem.add_runtime_dependency 'activesupport', '>= 4.2'
-  gem.add_runtime_dependency 'ostruct', '~> 0.6'
 
   gem.name = 'hutch'
   gem.summary = 'Opinionated asynchronous inter-service communication using RabbitMQ'

--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -1,7 +1,6 @@
 require 'active_support/core_ext/object/blank'
 
 require 'carrot-top'
-require 'ostruct'
 require 'hutch/logging'
 require 'hutch/exceptions'
 require 'hutch/publisher'
@@ -269,8 +268,11 @@ module Hutch
 
     private
 
+    Config = Struct.new(:host, :port, :username, :password, :ssl, :protocol, :sanitized_uri)
+    private_constant :Config
+
     def api_config
-      @api_config ||= OpenStruct.new.tap do |config|
+      @api_config ||= Config.new.tap do |config|
         config.host = @config[:mq_api_host]
         config.port = @config[:mq_api_port]
         config.username = @config[:mq_username]

--- a/spec/hutch/error_handlers/airbrake_spec.rb
+++ b/spec/hutch/error_handlers/airbrake_spec.rb
@@ -14,7 +14,7 @@ describe Hutch::ErrorHandlers::Airbrake do
 
     it "logs the error to Airbrake" do
       message_id = "1"
-      properties = OpenStruct.new(message_id: message_id)
+      properties = Struct.new(:message_id).new(message_id)
       payload = "{}"
       consumer = double
       ex = error

--- a/spec/hutch/error_handlers/bugsnag_spec.rb
+++ b/spec/hutch/error_handlers/bugsnag_spec.rb
@@ -23,7 +23,7 @@ describe Hutch::ErrorHandlers::Bugsnag do
 
     it "logs the error to Bugsnag" do
       message_id = "1"
-      properties = OpenStruct.new(message_id: message_id)
+      properties = Struct.new(:message_id).new(message_id)
       payload = "{}"
       consumer = double
       ex = error

--- a/spec/hutch/error_handlers/honeybadger_spec.rb
+++ b/spec/hutch/error_handlers/honeybadger_spec.rb
@@ -14,7 +14,7 @@ describe Hutch::ErrorHandlers::Honeybadger do
 
     it "logs the error to Honeybadger" do
       message_id = "1"
-      properties = OpenStruct.new(message_id: message_id)
+      properties = Struct.new(:message_id).new(message_id)
       payload = "{}"
       consumer = double
       ex = error

--- a/spec/hutch/error_handlers/logger_spec.rb
+++ b/spec/hutch/error_handlers/logger_spec.rb
@@ -4,7 +4,7 @@ describe Hutch::ErrorHandlers::Logger do
   let(:error_handler) { Hutch::ErrorHandlers::Logger.new }
 
   describe '#handle' do
-    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:properties) { Struct.new(:message_id).new("1") }
     let(:payload) { "{}" }
     let(:error) { double(message: "Stuff went wrong", class: "RuntimeError",
                        backtrace: ["line 1", "line 2"]) }

--- a/spec/hutch/error_handlers/rollbar_spec.rb
+++ b/spec/hutch/error_handlers/rollbar_spec.rb
@@ -14,7 +14,7 @@ describe Hutch::ErrorHandlers::Rollbar do
 
     it "logs the error to Rollbar" do
       message_id = "1"
-      properties = OpenStruct.new(message_id: message_id)
+      properties = Struct.new(:message_id).new(message_id)
       payload = "{}"
       consumer = double
       ex = error

--- a/spec/hutch/error_handlers/sentry_raven_spec.rb
+++ b/spec/hutch/error_handlers/sentry_raven_spec.rb
@@ -4,7 +4,7 @@ describe Hutch::ErrorHandlers::SentryRaven do
   let(:error_handler) { Hutch::ErrorHandlers::SentryRaven.new }
 
   describe '#handle' do
-    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:properties) { Struct.new(:message_id).new("1") }
     let(:payload) { "{}" }
     let(:error) do
       begin

--- a/spec/hutch/error_handlers/sentry_spec.rb
+++ b/spec/hutch/error_handlers/sentry_spec.rb
@@ -12,7 +12,7 @@ describe Hutch::ErrorHandlers::Sentry do
   end
 
   describe '#handle' do
-    let(:properties) { OpenStruct.new(message_id: "1") }
+    let(:properties) { Struct.new(:message_id).new("1") }
     let(:payload) { "{}" }
     let(:error) do
       begin

--- a/spec/hutch/tracers/datadog_spec.rb
+++ b/spec/hutch/tracers/datadog_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hutch::Tracers::Datadog do
         end
 
         def class
-          OpenStruct.new(name: 'ClassName')
+          Struct.new(:name).new('ClassName')
         end
 
         def process(message)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ end
 require 'raven'
 require 'hutch'
 require 'logger'
-require 'ostruct'
 
 # set logger to be a null logger
 Hutch::Logging.logger = Logger.new(File::NULL)


### PR DESCRIPTION
The only usage in library code was to hold the config and that is never exposed to users. Just use a normal struct for that.